### PR TITLE
[SPA-69] Implement select default group

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,9 @@ dependencies {
     //Glide
     implementation(libs.glide)
 
+    //Datastore
+    implementation(libs.datastore)
+
     //Room
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)

--- a/app/src/main/java/com/madteam/split/data/repository/datastore/DatastoreManager.kt
+++ b/app/src/main/java/com/madteam/split/data/repository/datastore/DatastoreManager.kt
@@ -3,6 +3,7 @@ package com.madteam.split.data.repository.datastore
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -11,6 +12,8 @@ import javax.inject.Inject
 interface DatastoreManager {
     suspend fun saveString(key: String, value: String)
     suspend fun getString(key: String): String?
+    suspend fun saveInt(key: String, value: Int)
+    suspend fun getInt(key: String): Int?
     suspend fun removeValue(key: String)
 }
 
@@ -27,6 +30,18 @@ class DatastoreManagerImpl @Inject constructor(
 
     override suspend fun getString(key: String): String? {
         val dataStoreKey = stringPreferencesKey(key)
+        return dataStore.data.map { it[dataStoreKey] }.first()
+    }
+
+    override suspend fun saveInt(key: String, value: Int) {
+        val dataStoreKey = intPreferencesKey(key)
+        dataStore.edit { preferences ->
+            preferences[dataStoreKey] = value
+        }
+    }
+
+    override suspend fun getInt(key: String): Int? {
+        val dataStoreKey = intPreferencesKey(key)
         return dataStore.data.map { it[dataStoreKey] }.first()
     }
 

--- a/app/src/main/java/com/madteam/split/data/repository/datastore/DatastoreManager.kt
+++ b/app/src/main/java/com/madteam/split/data/repository/datastore/DatastoreManager.kt
@@ -1,0 +1,39 @@
+package com.madteam.split.data.repository.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+interface DatastoreManager {
+    suspend fun saveString(key: String, value: String)
+    suspend fun getString(key: String): String?
+    suspend fun removeValue(key: String)
+}
+
+class DatastoreManagerImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : DatastoreManager {
+
+    override suspend fun saveString(key: String, value: String) {
+        val dataStoreKey = stringPreferencesKey(key)
+        dataStore.edit { preferences ->
+            preferences[dataStoreKey] = value
+        }
+    }
+
+    override suspend fun getString(key: String): String? {
+        val dataStoreKey = stringPreferencesKey(key)
+        return dataStore.data.map { it[dataStoreKey] }.first()
+    }
+
+    override suspend fun removeValue(key: String) {
+        val dataStoreKey = stringPreferencesKey(key)
+        dataStore.edit { preferences ->
+            preferences.remove(dataStoreKey)
+        }
+    }
+}

--- a/app/src/main/java/com/madteam/split/di/CommonsModule.kt
+++ b/app/src/main/java/com/madteam/split/di/CommonsModule.kt
@@ -1,0 +1,10 @@
+package com.madteam.split.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CommonsModule {
+}

--- a/app/src/main/java/com/madteam/split/di/storage/StorageModule.kt
+++ b/app/src/main/java/com/madteam/split/di/storage/StorageModule.kt
@@ -4,8 +4,13 @@ import android.app.Application
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import com.madteam.split.data.database.user.UserDatabase
+import com.madteam.split.data.repository.datastore.DatastoreManager
+import com.madteam.split.data.repository.datastore.DatastoreManagerImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,10 +25,30 @@ private const val USER_DATABASE_NAME = "user_database"
 @InstallIn(SingletonComponent::class)
 object StorageModule {
 
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "userSettings"
+    )
+
     @Provides
     @Singleton
     fun provideSharedPref(app: Application): SharedPreferences {
         return app.getSharedPreferences("prefs", MODE_PRIVATE)
+    }
+
+    @Provides
+    @Singleton
+    fun providePreferencesDataStore(app: Application): DataStore<Preferences> {
+        return app.dataStore
+    }
+
+    @Provides
+    @Singleton
+    fun provideDatastoreManager(
+        datastore: DataStore<Preferences>,
+    ): DatastoreManager {
+        return DatastoreManagerImpl(
+            datastore
+        )
     }
 
     @Provides

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIEvent.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIEvent.kt
@@ -1,6 +1,9 @@
 package com.madteam.split.ui.screens.mygroups.state
 
+import com.madteam.split.domain.model.Group
+
 sealed class MyGroupsUIEvent {
     data object OnCreateNewGroupClick : MyGroupsUIEvent()
     data object OnRefreshGroupsList : MyGroupsUIEvent()
+    data class OnGroupSelected(val group: Group?) : MyGroupsUIEvent()
 }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIEvent.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIEvent.kt
@@ -5,5 +5,5 @@ import com.madteam.split.domain.model.Group
 sealed class MyGroupsUIEvent {
     data object OnCreateNewGroupClick : MyGroupsUIEvent()
     data object OnRefreshGroupsList : MyGroupsUIEvent()
-    data class OnGroupSelected(val group: Group?) : MyGroupsUIEvent()
+    data class OnGroupSelected(val group: Group?, val isDefault: Boolean) : MyGroupsUIEvent()
 }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIEvent.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIEvent.kt
@@ -6,4 +6,5 @@ sealed class MyGroupsUIEvent {
     data object OnCreateNewGroupClick : MyGroupsUIEvent()
     data object OnRefreshGroupsList : MyGroupsUIEvent()
     data class OnGroupSelected(val group: Group?, val isDefault: Boolean) : MyGroupsUIEvent()
+    data class OnGroupSelectedAsDefault(val groupId: Int) : MyGroupsUIEvent()
 }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
@@ -8,4 +8,5 @@ data class MyGroupsUIState(
     val userGroups: List<Group> = listOf(),
     val isGroupsListLoading: Boolean = false,
     val groupSelected: Group? = null,
+    val groupSelectedIsDefault: Boolean = false,
 )

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
@@ -7,4 +7,5 @@ data class MyGroupsUIState(
     val userInfo: User = User(0, "", "", "", ""),
     val userGroups: List<Group> = listOf(),
     val isGroupsListLoading: Boolean = false,
+    val groupSelected: Group? = null,
 )

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
@@ -8,6 +8,5 @@ data class MyGroupsUIState(
     val userGroups: List<Group> = listOf(),
     val isGroupsListLoading: Boolean = false,
     val groupSelected: Group? = null,
-    val groupSelectedIsDefault: Boolean = false,
-    val defaultGroup: String = "",
+    val defaultGroup: Int? = null,
 )

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/state/MyGroupsUIState.kt
@@ -9,4 +9,5 @@ data class MyGroupsUIState(
     val isGroupsListLoading: Boolean = false,
     val groupSelected: Group? = null,
     val groupSelectedIsDefault: Boolean = false,
+    val defaultGroup: String = "",
 )

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
@@ -1,5 +1,6 @@
 package com.madteam.split.ui.screens.mygroups.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -34,6 +35,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -55,10 +57,12 @@ import com.madteam.split.ui.screens.mygroups.state.MyGroupsUIEvent
 import com.madteam.split.ui.screens.mygroups.state.MyGroupsUIState
 import com.madteam.split.ui.screens.mygroups.viewmodel.MyGroupsViewModel
 import com.madteam.split.ui.theme.GroupSettingsModalBottomSheet
+import com.madteam.split.ui.theme.InfoMessage
 import com.madteam.split.ui.theme.PrimaryLargeButton
 import com.madteam.split.ui.theme.ProfileImage
 import com.madteam.split.ui.theme.SecondaryLargeButton
 import com.madteam.split.ui.theme.SplitTheme
+import com.madteam.split.utils.misc.VibrationUtils
 import com.madteam.split.utils.ui.BackPressHandler
 
 @Composable
@@ -76,7 +80,7 @@ fun MyGroupsScreen(
     if (state.groupSelected != null) {
         GroupSettingsModalBottomSheet(
             group = state.groupSelected!!,
-            isDefault = state.groupSelectedIsDefault,
+            isDefault = state.groupSelected!!.id.toString() == state.defaultGroup,
             onClose = {
                 viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(null, false))
             },
@@ -130,6 +134,12 @@ fun MyGroupsContent(
             navigateTo = navigateTo
         )
         Spacer(modifier = Modifier.size(8.dp))
+        AnimatedVisibility(visible = state.defaultGroup == "") {
+            InfoMessage(
+                messageText = R.string.select_default_group_info_message,
+                titleText = R.string.pro_tip,
+            )
+        }
         SwipeRefresh(
             state = swipeRefreshState,
             onRefresh = {
@@ -216,6 +226,7 @@ private fun GroupListItem(
     isDefault: Boolean = false,
     onGroupSelected: (Group, Boolean) -> Unit,
 ) {
+    val context = LocalContext.current
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -225,12 +236,20 @@ private fun GroupListItem(
                 detectTapGestures(
                     onLongPress = {
                         onGroupSelected(group, isDefault)
+                        VibrationUtils.vibrate(
+                            context = context,
+                            duration = 50
+                        )
+                    },
+                    onTap = {
+                        //Not implemented yet
                     }
                 )
             },
         shape = RoundedCornerShape(20.dp),
         elevation = CardDefaults.elevatedCardElevation(
-            defaultElevation = 8.dp
+            defaultElevation = 8.dp,
+            pressedElevation = 0.dp,
         ),
         colors = CardDefaults.elevatedCardColors(
             containerColor = SplitTheme.colors.secondary.backgroundMedium

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
@@ -80,7 +80,7 @@ fun MyGroupsScreen(
     if (state.groupSelected != null) {
         GroupSettingsModalBottomSheet(
             group = state.groupSelected!!,
-            isDefault = state.groupSelected!!.id.toString() == state.defaultGroup,
+            isDefault = state.groupSelected!!.id == state.defaultGroup,
             onClose = {
                 viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(null, false))
             },
@@ -134,7 +134,7 @@ fun MyGroupsContent(
             navigateTo = navigateTo
         )
         Spacer(modifier = Modifier.size(8.dp))
-        AnimatedVisibility(visible = state.defaultGroup == "") {
+        AnimatedVisibility(visible = state.defaultGroup == null) {
             InfoMessage(
                 messageText = R.string.select_default_group_info_message,
                 titleText = R.string.pro_tip,
@@ -153,7 +153,7 @@ fun MyGroupsContent(
                 itemsIndexed(state.userGroups) { _, group ->
                     GroupListItem(
                         group = group,
-                        isDefault = state.defaultGroup == group.id.toString(),
+                        isDefault = state.defaultGroup == group.id,
                         onGroupSelected = { selected, isDefault ->
                             onGroupSelected(selected, isDefault)
                         }
@@ -348,7 +348,7 @@ fun MembersListItemList(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy((-8).dp)
     ) {
-        members.forEachIndexed { index, member ->
+        members.forEachIndexed { _, member ->
             Box(
                 modifier = Modifier
                     .shadow(

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
@@ -79,6 +79,13 @@ fun MyGroupsScreen(
             isDefault = state.groupSelectedIsDefault,
             onClose = {
                 viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(null, false))
+            },
+            onGroupDefault = { selectedGroupId ->
+                viewModel.onEvent(
+                    MyGroupsUIEvent.OnGroupSelectedAsDefault(
+                        selectedGroupId
+                    )
+                )
             }
         )
     }
@@ -136,7 +143,7 @@ fun MyGroupsContent(
                 itemsIndexed(state.userGroups) { _, group ->
                     GroupListItem(
                         group = group,
-                        isDefault = false,
+                        isDefault = state.defaultGroup == group.id.toString(),
                         onGroupSelected = { selected, isDefault ->
                             onGroupSelected(selected, isDefault)
                         }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
@@ -2,6 +2,7 @@ package com.madteam.split.ui.screens.mygroups.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +32,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -53,6 +55,7 @@ import com.madteam.split.ui.navigation.Screens
 import com.madteam.split.ui.screens.mygroups.state.MyGroupsUIEvent
 import com.madteam.split.ui.screens.mygroups.state.MyGroupsUIState
 import com.madteam.split.ui.screens.mygroups.viewmodel.MyGroupsViewModel
+import com.madteam.split.ui.theme.GroupSettingsModalBottomSheet
 import com.madteam.split.ui.theme.PrimaryLargeButton
 import com.madteam.split.ui.theme.ProfileImage
 import com.madteam.split.ui.theme.SecondaryLargeButton
@@ -71,6 +74,15 @@ fun MyGroupsScreen(
 
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    if (state.groupSelected != null) {
+        GroupSettingsModalBottomSheet(
+            group = state.groupSelected!!,
+            onClose = {
+                viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(null))
+            }
+        )
+    }
+
     Scaffold(
         containerColor = SplitTheme.colors.neutral.backgroundExtraWeak
     ) {
@@ -84,7 +96,10 @@ fun MyGroupsScreen(
                 onRefreshGroups = {
                     viewModel.onEvent(MyGroupsUIEvent.OnRefreshGroupsList)
                 },
-                navigateTo = navController::navigate
+                onGroupSelected = { group ->
+                    viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(group))
+                },
+                navigateTo = navController::navigate,
             )
         }
     }
@@ -95,6 +110,7 @@ fun MyGroupsContent(
     state: MyGroupsUIState,
     onRefreshGroups: () -> Unit,
     navigateTo: (String) -> Unit,
+    onGroupSelected: (Group) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -120,7 +136,8 @@ fun MyGroupsContent(
                 itemsIndexed(state.userGroups) { _, group ->
                     GroupListItem(
                         group = group,
-                        isDefault = false
+                        isDefault = false,
+                        onGroupSelected = { onGroupSelected(it) }
                     )
                 }
             }
@@ -188,12 +205,20 @@ fun MyGroupsTopBar(
 private fun GroupListItem(
     group: Group,
     isDefault: Boolean = false,
+    onGroupSelected: (Group) -> Unit,
 ) {
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 16.dp)
-            .size(124.dp),
+            .size(124.dp)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onLongPress = {
+                        onGroupSelected(group)
+                    }
+                )
+            },
         shape = RoundedCornerShape(20.dp),
         elevation = CardDefaults.elevatedCardElevation(
             defaultElevation = 8.dp
@@ -336,7 +361,8 @@ fun GroupListItemPreview() {
                 ),
             )
         ),
-        isDefault = true
+        isDefault = true,
+        {}
     )
 }
 

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/ui/MyGroupsScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -77,8 +76,9 @@ fun MyGroupsScreen(
     if (state.groupSelected != null) {
         GroupSettingsModalBottomSheet(
             group = state.groupSelected!!,
+            isDefault = state.groupSelectedIsDefault,
             onClose = {
-                viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(null))
+                viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(null, false))
             }
         )
     }
@@ -96,8 +96,8 @@ fun MyGroupsScreen(
                 onRefreshGroups = {
                     viewModel.onEvent(MyGroupsUIEvent.OnRefreshGroupsList)
                 },
-                onGroupSelected = { group ->
-                    viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(group))
+                onGroupSelected = { group, isDefault ->
+                    viewModel.onEvent(MyGroupsUIEvent.OnGroupSelected(group, isDefault))
                 },
                 navigateTo = navController::navigate,
             )
@@ -110,7 +110,7 @@ fun MyGroupsContent(
     state: MyGroupsUIState,
     onRefreshGroups: () -> Unit,
     navigateTo: (String) -> Unit,
-    onGroupSelected: (Group) -> Unit,
+    onGroupSelected: (Group, Boolean) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -137,7 +137,9 @@ fun MyGroupsContent(
                     GroupListItem(
                         group = group,
                         isDefault = false,
-                        onGroupSelected = { onGroupSelected(it) }
+                        onGroupSelected = { selected, isDefault ->
+                            onGroupSelected(selected, isDefault)
+                        }
                     )
                 }
             }
@@ -205,7 +207,7 @@ fun MyGroupsTopBar(
 private fun GroupListItem(
     group: Group,
     isDefault: Boolean = false,
-    onGroupSelected: (Group) -> Unit,
+    onGroupSelected: (Group, Boolean) -> Unit,
 ) {
     ElevatedCard(
         modifier = Modifier
@@ -215,7 +217,7 @@ private fun GroupListItem(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onLongPress = {
-                        onGroupSelected(group)
+                        onGroupSelected(group, isDefault)
                     }
                 )
             },
@@ -308,62 +310,6 @@ private fun GroupListItem(
         }
 
     }
-}
-
-@Preview
-@Composable
-fun GroupListItemPreview() {
-    GroupListItem(
-        group = Group(
-            id = 10,
-            name = "Amsterdam",
-            description = "",
-            inviteCode = "R2PZMT",
-            image = "",
-            bannerImage = "",
-            createdDate = "2024-01-21 18:28:42",
-            members = listOf(
-                Member(
-                    id = 21,
-                    name = "adria",
-                    profileImage = "",
-                    user = 5,
-                    color = "",
-                    joinedDate = "2024-01-21 18:28:42",
-                    groupId = 10
-                ),
-                Member(
-                    id = 22,
-                    name = "david",
-                    profileImage = "",
-                    user = null,
-                    color = "",
-                    joinedDate = "2024-01-21 18:28:42",
-                    groupId = 10
-                ),
-                Member(
-                    id = 23,
-                    name = "Berni",
-                    profileImage = "",
-                    user = null,
-                    color = "",
-                    joinedDate = "2024-01-21 18:28:42",
-                    groupId = 10
-                ),
-                Member(
-                    id = 24,
-                    name = "Oscar",
-                    profileImage = "",
-                    user = null,
-                    color = "",
-                    joinedDate = "2024-01-21 18:28:42",
-                    groupId = 10
-                ),
-            )
-        ),
-        isDefault = true,
-        {}
-    )
 }
 
 @OptIn(ExperimentalGlideComposeApi::class)

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.madteam.split.data.repository.group.GroupRepository
 import com.madteam.split.data.repository.user.UserRepository
+import com.madteam.split.domain.model.Group
 import com.madteam.split.ui.screens.mygroups.state.MyGroupsUIEvent
 import com.madteam.split.ui.screens.mygroups.state.MyGroupsUIState
 import com.madteam.split.utils.network.Resource
@@ -37,6 +38,10 @@ class MyGroupsViewModel @Inject constructor(
 
             is MyGroupsUIEvent.OnRefreshGroupsList -> {
                 reloadUserGroups()
+            }
+
+            is MyGroupsUIEvent.OnGroupSelected -> {
+                setSelectedGroup(event.group)
             }
         }
     }
@@ -102,5 +107,11 @@ class MyGroupsViewModel @Inject constructor(
                 isGroupsListLoading = false
             )
         }
+    }
+
+    private fun setSelectedGroup(group: Group?) {
+        _state.value = _state.value.copy(
+            groupSelected = group
+        )
     }
 }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
@@ -45,8 +45,7 @@ class MyGroupsViewModel @Inject constructor(
 
             is MyGroupsUIEvent.OnGroupSelected -> {
                 setSelectedGroup(
-                    group = event.group,
-                    isDefault = event.isDefault
+                    group = event.group
                 )
             }
 
@@ -119,20 +118,19 @@ class MyGroupsViewModel @Inject constructor(
         }
     }
 
-    private fun setSelectedGroup(group: Group?, isDefault: Boolean) {
+    private fun setSelectedGroup(group: Group?) {
         _state.value = _state.value.copy(
-            groupSelected = group,
-            groupSelectedIsDefault = isDefault
+            groupSelected = group
         )
     }
 
     private fun retrieveDefaultGroup() {
         viewModelScope.launch {
             try {
-                val defaultGroup = dataStoreManager.getString("mainGroupId")
-                if (defaultGroup.isNullOrBlank()) {
+                val defaultGroup = dataStoreManager.getInt("mainGroupId")
+                if (defaultGroup == null) {
                     _state.value = _state.value.copy(
-                        defaultGroup = ""
+                        defaultGroup = null
                     )
                 } else {
                     _state.value = _state.value.copy(
@@ -148,20 +146,20 @@ class MyGroupsViewModel @Inject constructor(
     private fun setSelectedGroupAsDefault(groupId: Int) {
         viewModelScope.launch {
             try {
-                val actualMainGroup = dataStoreManager.getString("mainGroupId")
-                if (actualMainGroup.isNullOrBlank() || actualMainGroup != groupId.toString()) {
-                    dataStoreManager.saveString("mainGroupId", groupId.toString())
+                val actualMainGroup = dataStoreManager.getInt("mainGroupId")
+                if (actualMainGroup == null || actualMainGroup != groupId) {
+                    dataStoreManager.saveInt("mainGroupId", groupId)
                     _state.value = _state.value.copy(
-                        defaultGroup = groupId.toString()
+                        defaultGroup = groupId
                     )
                 } else {
                     dataStoreManager.removeValue("mainGroupId")
                     _state.value = _state.value.copy(
-                        defaultGroup = ""
+                        defaultGroup = null
                     )
                 }
             } catch (e: Exception) {
-                println("Error saving default group")
+                println("Error saving default group: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
@@ -30,6 +30,7 @@ class MyGroupsViewModel @Inject constructor(
         getUserGroups(
             update = false
         )
+        retrieveDefaultGroup()
     }
 
     fun onEvent(event: MyGroupsUIEvent) {
@@ -125,6 +126,25 @@ class MyGroupsViewModel @Inject constructor(
         )
     }
 
+    private fun retrieveDefaultGroup() {
+        viewModelScope.launch {
+            try {
+                val defaultGroup = dataStoreManager.getString("mainGroupId")
+                if (defaultGroup.isNullOrBlank()) {
+                    _state.value = _state.value.copy(
+                        defaultGroup = ""
+                    )
+                } else {
+                    _state.value = _state.value.copy(
+                        defaultGroup = defaultGroup
+                    )
+                }
+            } catch (e: Exception) {
+                println("Error retrieving default group")
+            }
+        }
+    }
+
     private fun setSelectedGroupAsDefault(groupId: Int) {
         viewModelScope.launch {
             try {
@@ -140,9 +160,6 @@ class MyGroupsViewModel @Inject constructor(
                         defaultGroup = ""
                     )
                 }
-                _state.value = _state.value.copy(
-                    defaultGroup = groupId.toString()
-                )
             } catch (e: Exception) {
                 println("Error saving default group")
             }

--- a/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
+++ b/app/src/main/java/com/madteam/split/ui/screens/mygroups/viewmodel/MyGroupsViewModel.kt
@@ -41,7 +41,10 @@ class MyGroupsViewModel @Inject constructor(
             }
 
             is MyGroupsUIEvent.OnGroupSelected -> {
-                setSelectedGroup(event.group)
+                setSelectedGroup(
+                    group = event.group,
+                    isDefault = event.isDefault
+                )
             }
         }
     }
@@ -109,9 +112,10 @@ class MyGroupsViewModel @Inject constructor(
         }
     }
 
-    private fun setSelectedGroup(group: Group?) {
+    private fun setSelectedGroup(group: Group?, isDefault: Boolean) {
         _state.value = _state.value.copy(
-            groupSelected = group
+            groupSelected = group,
+            groupSelectedIsDefault = isDefault
         )
     }
 }

--- a/app/src/main/java/com/madteam/split/ui/theme/Modals.kt
+++ b/app/src/main/java/com/madteam/split/ui/theme/Modals.kt
@@ -112,6 +112,7 @@ fun GroupSettingsModalBottomSheet(
     group: Group,
     isDefault: Boolean,
     onClose: () -> Unit,
+    onGroupDefault: (Int) -> Unit,
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState()
     BackHandler {
@@ -196,6 +197,9 @@ fun GroupSettingsModalBottomSheet(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .clickable {
+                        onGroupDefault(group.id)
+                    }
             ) {
                 Icon(
                     imageVector = if (isDefault) {

--- a/app/src/main/java/com/madteam/split/ui/theme/Modals.kt
+++ b/app/src/main/java/com/madteam/split/ui/theme/Modals.kt
@@ -2,11 +2,13 @@ package com.madteam.split.ui.theme
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -14,6 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.RemoveCircle
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -24,11 +29,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
@@ -104,6 +110,7 @@ fun DSModalBottomSheet(
 @Composable
 fun GroupSettingsModalBottomSheet(
     group: Group,
+    isDefault: Boolean,
     onClose: () -> Unit,
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState()
@@ -119,14 +126,13 @@ fun GroupSettingsModalBottomSheet(
     ) {
         ConstraintLayout(
             modifier = Modifier
-                .fillMaxSize()
         ) {
-            val (bannerImage) = createRefs()
+            val (bannerImage, degrade, groupName) = createRefs()
             if (group.bannerImage.isNotEmpty()) {
                 GlideImage(
                     modifier = Modifier
                         .wrapContentWidth()
-                        .height(60.dp)
+                        .height(100.dp)
                         .constrainAs(bannerImage) {
                             top.linkTo(parent.top)
                             start.linkTo(parent.start)
@@ -152,24 +158,68 @@ fun GroupSettingsModalBottomSheet(
                     contentDescription = stringResource(id = R.string.group_banner_image),
                 )
             }
+            Box(
+                modifier = Modifier
+                    .height(100.dp)
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                Color.Black
+                            )
+                        )
+                    )
+                    .constrainAs(degrade) {
+                        top.linkTo(bannerImage.top)
+                        start.linkTo(bannerImage.start)
+                        end.linkTo(bannerImage.end)
+                        bottom.linkTo(bannerImage.bottom)
+                    }
+            )
+            Text(
+                modifier = Modifier
+                    .constrainAs(groupName) {
+                        bottom.linkTo(bannerImage.bottom, 16.dp)
+                        start.linkTo(parent.start, 24.dp)
+                    },
+                text = group.name,
+                style = SplitTheme.typography.heading.s,
+                color = SplitTheme.colors.neutral.textExtraWeak,
+            )
+
+        }
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = if (isDefault) {
+                        Icons.Filled.RemoveCircle
+                    } else {
+                        Icons.Filled.Home
+                    },
+                    contentDescription = null,
+                    tint = SplitTheme.colors.neutral.iconHeavy,
+                )
+                Spacer(modifier = Modifier.size(24.dp))
+                Text(
+                    text = if (isDefault) {
+                        stringResource(
+                            id = R.string.remove_this_group_as_default
+                        ) // It will be different when logic implemented
+                    } else {
+                        stringResource(id = R.string.mark_this_group_as_default)
+                    },
+                    style = SplitTheme.typography.body.l,
+                    color = SplitTheme.colors.neutral.textTitle,
+                )
+            }
+            Spacer(modifier = Modifier.size(32.dp))
         }
     }
-}
-
-@Preview
-@Composable
-fun DSModalBottomSheetPreview() {
-    GroupSettingsModalBottomSheet(
-        group = Group(
-            id = 1,
-            name = "Group Name",
-            members = listOf(),
-            description = "",
-            image = "",
-            inviteCode = "",
-            bannerImage = "",
-            createdDate = "23/11/2001"
-        ),
-        {}
-    )
 }

--- a/app/src/main/java/com/madteam/split/ui/theme/Modals.kt
+++ b/app/src/main/java/com/madteam/split/ui/theme/Modals.kt
@@ -1,19 +1,19 @@
 package com.madteam.split.ui.theme
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.EmojiEmotions
-import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -23,25 +23,32 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import com.madteam.split.R
+import com.madteam.split.domain.model.Group
 
 data class ModalOption(
     val icon: ImageVector,
     val iconDescription: Int,
     val title: Int,
     val action: () -> Unit,
-    val isDangerOption: Boolean = false
+    val isDangerOption: Boolean = false,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DSModalBottomSheet(
     optionsList: List<ModalOption>,
-    onClose: () -> Unit
+    onClose: () -> Unit,
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState()
     BackHandler {
@@ -93,30 +100,76 @@ fun DSModalBottomSheet(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class)
+@Composable
+fun GroupSettingsModalBottomSheet(
+    group: Group,
+    onClose: () -> Unit,
+) {
+    val modalBottomSheetState = rememberModalBottomSheetState()
+    BackHandler {
+        onClose()
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = { onClose() },
+        sheetState = modalBottomSheetState,
+        dragHandle = {},
+        containerColor = SplitTheme.colors.neutral.backgroundExtraWeak,
+    ) {
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            val (bannerImage) = createRefs()
+            if (group.bannerImage.isNotEmpty()) {
+                GlideImage(
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .height(60.dp)
+                        .constrainAs(bannerImage) {
+                            top.linkTo(parent.top)
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                        },
+                    contentScale = ContentScale.Crop,
+                    model = group.bannerImage,
+                    contentDescription = stringResource(id = R.string.group_banner_image)
+                )
+            } else {
+                Image(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp)
+                        .rotate(180f)
+                        .constrainAs(bannerImage) {
+                            top.linkTo(parent.top)
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                        },
+                    contentScale = ContentScale.Crop,
+                    painter = painterResource(id = R.drawable.default_group_banner_image),
+                    contentDescription = stringResource(id = R.string.group_banner_image),
+                )
+            }
+        }
+    }
+}
+
 @Preview
 @Composable
 fun DSModalBottomSheetPreview() {
-    DSModalBottomSheet(
-        onClose = {},
-        optionsList = mutableListOf(
-            ModalOption(
-                iconDescription = R.string.edit_icon_description,
-                icon = Icons.Outlined.Image,
-                title = R.string.update_profile_image_from_device,
-                action = {}
-            ),
-            ModalOption(
-                iconDescription = R.string.edit_icon_description,
-                icon = Icons.Outlined.Delete,
-                title = R.string.delete_profile_image,
-                action = {}
-            ),
-            ModalOption(
-                iconDescription = R.string.edit_icon_description,
-                icon = Icons.Outlined.EmojiEmotions,
-                title = R.string.choose_an_avatar,
-                action = {}
-            )
-        )
+    GroupSettingsModalBottomSheet(
+        group = Group(
+            id = 1,
+            name = "Group Name",
+            members = listOf(),
+            description = "",
+            image = "",
+            inviteCode = "",
+            bannerImage = "",
+            createdDate = "23/11/2001"
+        ),
+        {}
     )
 }

--- a/app/src/main/java/com/madteam/split/utils/misc/VibrationUtils.kt
+++ b/app/src/main/java/com/madteam/split/utils/misc/VibrationUtils.kt
@@ -1,0 +1,24 @@
+package com.madteam.split.utils.misc
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+object VibrationUtils {
+
+    fun vibrate(context: Context, duration: Long) {
+        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager =
+                context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            vibratorManager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+        val vibrationEffect =
+            VibrationEffect.createOneShot(duration, VibrationEffect.DEFAULT_AMPLITUDE)
+        vibrator.vibrate(vibrationEffect)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,4 +100,6 @@
   <string name="group_banner_image">Group banner image</string>
   <string name="mark_this_group_as_default">Mark this group as default one.</string>
   <string name="remove_this_group_as_default">Remove this group as default one.</string>
+  <string name="pro_tip">Pro tip!</string>
+  <string name="select_default_group_info_message">You can select a default group that will be opened directly when you launch Split. Just make a long press on the group and make it your default one!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,4 +98,6 @@
   <string name="go_to_my_groups">Go to my groups</string>
   <string name="error_creating_group">There has been an error trying to create the group. Try it later or contact support.</string>
   <string name="group_banner_image">Group banner image</string>
+  <string name="mark_this_group_as_default">Mark this group as default one.</string>
+  <string name="remove_this_group_as_default">Remove this group as default one.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ room = "2.6.1"
 firebaseBom = "32.7.1"
 googleServices = "4.4.0"
 swipeRefresh = "0.27.0"
+datastore = "1.0.0"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -65,6 +66,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-storage = { module = "com.google.firebase:firebase-storage" }
 swiperefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version.ref = "swipeRefresh" }
+datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# [SPA-69] Implement select default group

## 📝 Description
This PR implements the possibility to save into datastore your default group, if you don't have a default group a pro tip message is shown.
Later on, this default group will be used to directly enter the group screen instead of showing groups screen.


![image](https://github.com/Mad-Development-Team/Split-Android-App/assets/128298030/0f5bc0e9-07d4-4ed3-b1e0-d74aef1ad66f)


## 📎 Util links
- [x] Jira: https://adrifernandevs.atlassian.net/browse/SPA-69


[SPA-69]: https://adrifernandevs.atlassian.net/browse/SPA-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ